### PR TITLE
feat: clone on project directory

### DIFF
--- a/ginto.yaml
+++ b/ginto.yaml
@@ -10,11 +10,12 @@ resources:
       default: nano
     platform: node
     build: >
-      rm -rf * && rm -rf .git &&
-      git clone {{ repository.url }} . --branch {{ repository.branch }} --depth 1 &&
+      rm -rf ./project &&
+      git clone {{ repository.url }} ./project --branch {{ repository.branch }} --depth 1 &&
+      cd ./project &&
       npm install &&
       {{ build }}
-    start: '{{ start }}'
+    start: cd ./project && {{ start }}
     https: true
 triggers:
   - type: github


### PR DESCRIPTION
Clone on working directory no longer works because of start.sh.
Clone again on project.
Tested.